### PR TITLE
Affichage des liens des services dans le Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,15 @@ install:
 	@echo "$(GREEN)Installation terminee !$(NC)"
 	@echo "Front-end : http://localhost:3000"
 	@echo "Back-end  : http://localhost:8000"
+	@echo "Adminer   : http://localhost:8080"
 	git config core.hooksPath .githooks
 
 start:
 	docker compose up -d
 	@echo "$(GREEN)Services demarres !$(NC)"
+	@echo "Front-end : http://localhost:3000"
+	@echo "Back-end  : http://localhost:8000"
+	@echo "Adminer   : http://localhost:8080"
 
 stop:
 	docker compose stop
@@ -40,6 +44,9 @@ restart:
 	docker compose stop
 	docker compose up -d
 	@echo "$(GREEN)Services redemarres !$(NC)"
+	@echo "Front-end : http://localhost:3000"
+	@echo "Back-end  : http://localhost:8000"
+	@echo "Adminer   : http://localhost:8080"
 
 mobile:
 	@bash scripts/mobile.sh


### PR DESCRIPTION
Cette PR améliore l'expérience développeur en affichant automatiquement les liens HTTP vers le Frontend, le Backend et Adminer lors de l'exécution des commandes make start, make restart et make install.