### PR TITLE
fix: filtrer /seances selon l'utilisateur authentifié par défaut

### DIFF
--- a/backend/app/Http/Controllers/SeanceController.php
+++ b/backend/app/Http/Controllers/SeanceController.php
@@ -15,9 +15,10 @@ class SeanceController extends Controller
 
     public function getSeances(Request $request)
     {
-        $seances = $this->seanceService->getSeances($request->only(
-            ['enseignant_id', 'groupe_id', 'cours_id', 'date_debut', 'date_fin', 'statut', 'par_page']
-        ));
+        $seances = $this->seanceService->getSeances(
+            $request->only(['enseignant_id', 'groupe_id', 'cours_id', 'date_debut', 'date_fin', 'statut', 'par_page']),
+            $request->user()
+        );
 
         return SeanceResource::collection($seances);
     }

--- a/backend/app/Services/SeanceService.php
+++ b/backend/app/Services/SeanceService.php
@@ -6,21 +6,30 @@ use App\Exceptions\Seance\ConflitSeanceException;
 use App\Exceptions\Seance\SalleOccupeeException;
 use App\Exceptions\Seance\SessionEmargementActiveException;
 use App\Models\Seance;
+use App\Models\User;
 use Illuminate\Support\Collection;
 
 class SeanceService
 {
-    // / Récupère les séances en fonction des filtres fournis
-    public function getSeances(array $filtres = []): \Illuminate\Pagination\LengthAwarePaginator|Collection
+    // Récupère les séances en fonction des filtres fournis et du rôle de l'utilisateur
+    public function getSeances(array $filtres = [], ?User $utilisateur = null): \Illuminate\Pagination\LengthAwarePaginator|Collection
     {
         $query = Seance::query();
 
-        if (isset($filtres['enseignant_id'])) {
-            $query->where('enseignant_id', $filtres['enseignant_id']);
-        }
+        // Filtre par défaut selon le rôle de l'utilisateur authentifié
+        if ($utilisateur && $utilisateur->hasRole('enseignant')) {
+            $query->where('enseignant_id', $utilisateur->id);
+        } elseif ($utilisateur && $utilisateur->hasRole('etudiant')) {
+            $query->where('groupe_id', $utilisateur->groupe_id);
+        } else {
+            // gestionnaire : filtres optionnels fournis par le client
+            if (isset($filtres['enseignant_id'])) {
+                $query->where('enseignant_id', $filtres['enseignant_id']);
+            }
 
-        if (isset($filtres['groupe_id'])) {
-            $query->where('groupe_id', $filtres['groupe_id']);
+            if (isset($filtres['groupe_id'])) {
+                $query->where('groupe_id', $filtres['groupe_id']);
+            }
         }
 
         if (isset($filtres['cours_id'])) {

--- a/backend/database/factories/UserFactory.php
+++ b/backend/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Groupe;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -49,7 +50,16 @@ class UserFactory extends Factory
     {
         return $this->withRole('etudiant')->state(fn (array $attributes) => [
             'ine' => fake()->unique()->numerify('###########'),
+            'groupe_id' => $attributes['groupe_id'] ?? Groupe::factory(),
         ]);
+    }
+
+    /**
+     * State pour un gestionnaire.
+     */
+    public function gestionnaire(): static
+    {
+        return $this->withRole('gestionnaire');
     }
 
     /**

--- a/backend/tests/Feature/FeatureTestCase.php
+++ b/backend/tests/Feature/FeatureTestCase.php
@@ -16,5 +16,6 @@ abstract class FeatureTestCase extends TestCase
 
         Role::create(['name' => 'enseignant', 'guard_name' => 'web']);
         Role::create(['name' => 'etudiant', 'guard_name' => 'web']);
+        Role::create(['name' => 'gestionnaire', 'guard_name' => 'web']);
     }
 }

--- a/backend/tests/Feature/SeanceControllerTest.php
+++ b/backend/tests/Feature/SeanceControllerTest.php
@@ -8,15 +8,39 @@ use App\Models\User;
 
 class SeanceControllerTest extends FeatureTestCase
 {
-    public function test_peut_recuperer_la_liste_des_seances(): void
+    public function test_enseignant_voit_uniquement_ses_seances(): void
     {
         $enseignant = User::factory()->enseignant()->create();
-        Seance::factory()->count(3)->create();
+        Seance::factory()->count(2)->create(['enseignant_id' => $enseignant->id]);
+        Seance::factory()->count(3)->create(); // autres enseignants
 
         $response = $this->actingAs($enseignant)->getJson('/api/seances');
 
         $response->assertStatus(200)
-            ->assertJsonCount(3);
+            ->assertJsonCount(2, 'data');
+    }
+
+    public function test_gestionnaire_voit_toutes_les_seances(): void
+    {
+        $gestionnaire = User::factory()->gestionnaire()->create();
+        Seance::factory()->count(4)->create();
+
+        $response = $this->actingAs($gestionnaire)->getJson('/api/seances');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(4, 'data');
+    }
+
+    public function test_etudiant_voit_uniquement_les_seances_de_son_groupe(): void
+    {
+        $etudiant = User::factory()->etudiant()->create();
+        Seance::factory()->count(2)->create(['groupe_id' => $etudiant->groupe_id]);
+        Seance::factory()->count(3)->create(); // autres groupes
+
+        $response = $this->actingAs($etudiant)->getJson('/api/seances');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(2, 'data');
     }
 
     public function test_peut_recuperer_une_seance_avec_ses_relations(): void
@@ -50,11 +74,12 @@ class SeanceControllerTest extends FeatureTestCase
     public function test_liste_seances_vide_retourne_tableau_vide(): void
     {
         $enseignant = User::factory()->enseignant()->create();
+        Seance::factory()->count(2)->create(); // séances d'autres enseignants
 
         $response = $this->actingAs($enseignant)->getJson('/api/seances');
 
         $response->assertStatus(200)
-            ->assertJson([]);
+            ->assertJsonCount(0, 'data');
     }
 
     public function test_seance_retourne_les_bons_champs_de_date(): void


### PR DESCRIPTION
## Problème

`GET /seances` renvoyait toutes les séances si `enseignant_id` était absent ou mal formé — problème de confidentialité.

## Solution

Filtrage automatique selon le rôle de l'utilisateur authentifié :

- **Enseignant** → uniquement ses propres séances (`enseignant_id = auth user`)
- **Étudiant** → uniquement les séances de son groupe (`groupe_id = user.groupe_id`)
- **Gestionnaire** → accès complet, filtres optionnels conservés (`enseignant_id`, `groupe_id`, etc.)

## Changements

- `SeanceService::getSeances()` accepte un `?User` et applique le filtre selon le rôle
- `SeanceController::getSeances()` passe `$request->user()` au service
- `UserFactory` : ajout state `gestionnaire()`, `groupe_id` auto pour l'étudiant
- `FeatureTestCase` : ajout du rôle `gestionnaire` dans setUp
- `SeanceControllerTest` : 3 nouveaux tests (enseignant, gestionnaire, étudiant)

## Plan de test

- [ ] Enseignant : ne voit que ses séances
- [ ] Étudiant : ne voit que les séances de son groupe
- [ ] Gestionnaire : voit toutes les séances, peut filtrer par `enseignant_id` / `groupe_id`
- [ ] 50 tests passent