### PR TITLE
feat: ajout enseignant_id sur Cours et protection par propriété

### DIFF
--- a/backend/app/Exceptions/CoursExisteDejaException.php
+++ b/backend/app/Exceptions/CoursExisteDejaException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use Illuminate\Http\JsonResponse;
+
+class CoursExisteDejaException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('Le cours existe déjà.');
+    }
+
+    public function render(): JsonResponse
+    {
+        return response()->json(['message' => $this->getMessage()], 409);
+    }
+}

--- a/backend/app/Http/Controllers/ControllerCours.php
+++ b/backend/app/Http/Controllers/ControllerCours.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Cours;
 use App\Services\CoursService;
 use Illuminate\Http\Request;
 
@@ -19,16 +18,10 @@ class ControllerCours extends Controller
 
     public function createCours(Request $req)
     {
-
         $nom = $req->input('nom');
 
         if (! $nom) {
             return response()->json('il faut un nom de cours', 400);
-        }
-
-        $existe = Cours::where('nom', $nom)->first();
-        if ($existe) {
-            return response()->json(['message' => 'Le cours existe déjà'], 409);
         }
 
         $cours = $this->coursService->createCours($nom);
@@ -42,10 +35,6 @@ class ControllerCours extends Controller
 
         if (! $nom) {
             return response()->json('il faut un nom de cours', 400);
-        }
-        $existe = Cours::where('nom', $nom)->first();
-        if ($existe) {
-            return response()->json(['message' => 'Le cours existe déjà'], 409);
         }
 
         $cours = $this->coursService->updateCours($id, $nom);

--- a/backend/app/Http/Controllers/ControllerCours.php
+++ b/backend/app/Http/Controllers/ControllerCours.php
@@ -3,75 +3,60 @@
 namespace App\Http\Controllers;
 
 use App\Models\Cours;
+use App\Services\CoursService;
 use Illuminate\Http\Request;
 
 class ControllerCours extends Controller
 {
+    public function __construct(private CoursService $coursService)
+    {
+    }
+
     public function getCours()
     {
-        $cours = Cours::all();
-
-        return $cours;
+        return response()->json($this->coursService->getCours(), 200);
     }
 
     public function createCours(Request $req)
     {
 
-        $lib = $req->input('nom');
+        $nom = $req->input('nom');
 
-        $verif = Cours::where('nom', $lib)->get();
-
-        foreach ($verif as $v) {
-            if ($v->nom) {
-                return response()->json(['message' => 'Le cours existe déjà'], 409);
-            }
+        if (! $nom) {
+            return response()->json('il faut un nom de cours', 400);
         }
 
-        $cours = Cours::create([
-            'nom' => $lib,
-        ]);
+        $existe = Cours::where('nom', $nom)->first();
+        if ($existe) {
+            return response()->json(['message' => 'Le cours existe déjà'], 409);
+        }
+
+        $cours = $this->coursService->createCours($nom);
 
         return response()->json($cours, 201);
     }
 
     public function updateCours(Request $req, $id)
     {
-        $cours = Cours::find($id);
+        $nom = $req->input('nom');
 
-        if ($cours) {
-            $lib = $req->input('nom');
-
-            if ($lib) {
-                $verif2 = Cours::where('nom', $lib)->get();
-
-                foreach ($verif2 as $v2) {
-                    if ($v2->nom) {
-                        return response()->json(['message' => 'Le cours existe déjà'], 409);
-                    }
-                }
-
-                $cours->nom = $lib;
-                $cours->Save();
-
-                return response()->json($cours, 200);
-            }
-
-            return response()->json('il faut un libelé', 400);
+        if (! $nom) {
+            return response()->json('il faut un nom de cours', 400);
+        }
+        $existe = Cours::where('nom', $nom)->first();
+        if ($existe) {
+            return response()->json(['message' => 'Le cours existe déjà'], 409);
         }
 
-        return response()->json('cours introuvable', 404);
+        $cours = $this->coursService->updateCours($id, $nom);
+
+        return response()->json($cours, 200);
     }
 
     public function deleteCours($id)
     {
-        $cours = Cours::find($id);
+        $this->coursService->deleteCours($id);
 
-        if ($cours) {
-            $cours->delete();
-
-            return response()->json('Le cours à bien été supprimé', 200);
-        }
-
-        return response()->json("Le cours n'a pas été trouver", 404);
+        return response()->json(['message' => 'Cours supprimé avec succès'], 200);
     }
 }

--- a/backend/app/Models/Cours.php
+++ b/backend/app/Models/Cours.php
@@ -11,7 +11,7 @@ class Cours extends Model
 
     protected $table = 'cours';
 
-    protected $fillable = ['nom'];
+    protected $fillable = ['nom', 'enseignant_id'];
 
     public function inscriptions()
     {
@@ -26,5 +26,10 @@ class Cours extends Model
     public function seances()
     {
         return $this->hasMany(Seance::class, 'cours_id');
+    }
+
+    public function enseignant()
+    {
+        return $this->belongsTo(User::class, 'enseignant_id');
     }
 }

--- a/backend/app/Services/CoursService.php
+++ b/backend/app/Services/CoursService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Exceptions\CoursExisteDejaException;
 use App\Exceptions\NonAutoriseException;
 use App\Models\Cours;
 use Illuminate\Support\Facades\Auth;
@@ -10,11 +11,15 @@ class CoursService
 {
     public function getCours()
     {
-        return Cours::all()->values();
+        return Cours::all();
     }
 
     public function createCours(string $nom): Cours
     {
+        if (Cours::where('nom', $nom)->exists()) {
+            throw new CoursExisteDejaException();
+        }
+
         return Cours::create([
             'nom' => $nom,
             'enseignant_id' => Auth::id(),
@@ -26,6 +31,10 @@ class CoursService
         $cours = Cours::findOrFail($id);
         if ($cours->enseignant_id !== Auth::id()) {
             throw new NonAutoriseException();
+        }
+
+        if (Cours::where('nom', $nom)->where('id', '!=', $id)->exists()) {
+            throw new CoursExisteDejaException();
         }
 
         $cours->nom = $nom;

--- a/backend/app/Services/CoursService.php
+++ b/backend/app/Services/CoursService.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\NonAutoriseException;
+use App\Models\Cours;
+use Illuminate\Support\Facades\Auth;
+
+class CoursService
+{
+    public function getCours()
+    {
+        return Cours::all()->values();
+    }
+
+    public function createCours(string $nom): Cours
+    {
+        return Cours::create([
+            'nom' => $nom,
+            'enseignant_id' => Auth::id(),
+        ]);
+    }
+
+    public function updateCours(int $id, string $nom): Cours
+    {
+        $cours = Cours::findOrFail($id);
+        if ($cours->enseignant_id !== Auth::id()) {
+            throw new NonAutoriseException();
+        }
+
+        $cours->nom = $nom;
+        $cours->save();
+
+        return $cours;
+    }
+
+    public function deleteCours(int $id): void
+    {
+        $cours = Cours::findOrFail($id);
+        if ($cours->enseignant_id !== Auth::id()) {
+            throw new NonAutoriseException();
+        }
+
+        $cours->delete();
+    }
+}

--- a/backend/database/migrations/2026_04_15_122129_add_enseignant_id_to_cours_table.php
+++ b/backend/database/migrations/2026_04_15_122129_add_enseignant_id_to_cours_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('cours', function (Blueprint $table) {
-            $table->foreignId('enseignant_id')->after('id')->nullable()->constrained('users')->onDelete('cascade');
+            $table->foreignId('enseignant_id')->after('id')->nullable()->constrained('users')->nullOnDelete();
         });
     }
 

--- a/backend/database/migrations/2026_04_15_122129_add_enseignant_id_to_cours_table.php
+++ b/backend/database/migrations/2026_04_15_122129_add_enseignant_id_to_cours_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('cours', function (Blueprint $table) {
+            $table->foreignId('enseignant_id')->after('id')->nullable()->constrained('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('cours', function (Blueprint $table) {
+            $table->dropForeign(['enseignant_id']);
+            $table->dropColumn('enseignant_id');
+        });
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -59,10 +59,13 @@ class DatabaseSeeder extends Seeder
         $enseignantFixe->assignRole('enseignant');
 
         $autresEnseignants = User::factory(4)->enseignant()->create();
+        $tousLesEnseignants = $autresEnseignants->prepend($enseignantFixe);
 
         // 4. Cours
         $this->command->info('Création des cours...');
-        $cours = Cours::factory(10)->create();
+        $cours = Cours::factory(10)
+            ->sequence(fn () => ['enseignant_id' => $tousLesEnseignants->random()->id])
+            ->create();
 
         // Créneaux horaires : 4 plages fixes (une par cours du groupe)
         $creneaux = [

--- a/backend/tests/Feature/CoursControllerTest.php
+++ b/backend/tests/Feature/CoursControllerTest.php
@@ -79,7 +79,7 @@ class CoursControllerTest extends FeatureTestCase
     {
         $enseignant = User::factory()->enseignant()->create();
         Cours::factory()->create(['nom' => 'Java']);
-        $cours = Cours::factory()->create(['nom' => 'Python']);
+        $cours = Cours::factory()->create(['nom' => 'Python', 'enseignant_id' => $enseignant->id]);
 
         $response = $this->actingAs($enseignant)->patchJson("/api/Cours/Modifier/{$cours->id}", [
             'nom' => 'Java',
@@ -96,6 +96,19 @@ class CoursControllerTest extends FeatureTestCase
         $response = $this->actingAs($enseignant)->patchJson("/api/Cours/Modifier/{$cours->id}", []);
 
         $response->assertStatus(400);
+    }
+
+    public function test_modification_cours_par_autre_enseignant_retourne_403(): void
+    {
+        $proprietaire = User::factory()->enseignant()->create();
+        $autreEnseignant = User::factory()->enseignant()->create();
+        $cours = Cours::factory()->create(['nom' => 'PHP', 'enseignant_id' => $proprietaire->id]);
+
+        $response = $this->actingAs($autreEnseignant)->patchJson("/api/Cours/Modifier/{$cours->id}", [
+            'nom' => 'PHP avancé',
+        ]);
+
+        $response->assertStatus(403);
     }
 
     public function test_modification_cours_introuvable_retourne_404(): void
@@ -120,6 +133,17 @@ class CoursControllerTest extends FeatureTestCase
 
         $response->assertStatus(200);
         $this->assertDatabaseMissing('cours', ['id' => $cours->id]);
+    }
+
+    public function test_suppression_cours_par_autre_enseignant_retourne_403(): void
+    {
+        $proprietaire = User::factory()->enseignant()->create();
+        $autreEnseignant = User::factory()->enseignant()->create();
+        $cours = Cours::factory()->create(['enseignant_id' => $proprietaire->id]);
+
+        $response = $this->actingAs($autreEnseignant)->deleteJson("/api/Cours/Supprimer/{$cours->id}");
+
+        $response->assertStatus(403);
     }
 
     public function test_suppression_cours_introuvable_retourne_404(): void

--- a/backend/tests/Feature/CoursControllerTest.php
+++ b/backend/tests/Feature/CoursControllerTest.php
@@ -63,7 +63,7 @@ class CoursControllerTest extends FeatureTestCase
     public function test_peut_modifier_un_cours(): void
     {
         $enseignant = User::factory()->enseignant()->create();
-        $cours = Cours::factory()->create(['nom' => 'PHP']);
+        $cours = Cours::factory()->create(['nom' => 'PHP', 'enseignant_id' => $enseignant->id]);
 
         $response = $this->actingAs($enseignant)->patchJson("/api/Cours/Modifier/{$cours->id}", [
             'nom' => 'PHP avancé',
@@ -114,7 +114,7 @@ class CoursControllerTest extends FeatureTestCase
     public function test_peut_supprimer_un_cours(): void
     {
         $enseignant = User::factory()->enseignant()->create();
-        $cours = Cours::factory()->create();
+        $cours = Cours::factory()->create(['enseignant_id' => $enseignant->id]);
 
         $response = $this->actingAs($enseignant)->deleteJson("/api/Cours/Supprimer/{$cours->id}");
 


### PR DESCRIPTION
## Résumé

- Migration : ajout de `enseignant_id` (FK nullable vers `users`) sur la table `cours`
- Model `Cours` : `enseignant_id` dans `$fillable` + relation `belongsTo(User)`
- `CoursService` créé : `createCours` assigne `Auth::id()`, `updateCours`/`deleteCours` vérifient la propriété et lèvent `NonAutoriseException` (403) si l'utilisateur n'est pas le propriétaire
- `ControllerCours` refactorisé pour déléguer au service
- Seeder mis à jour : les cours créés ont un `enseignant_id` assigné parmi les enseignants disponibles

Closes #42

## Plan de test

- [x] `make fresh` → vérifier que le seeder tourne sans erreur
- [x] `make test` → 66 tests passent
- [x] Créer un cours en tant qu'enseignant → `enseignant_id` est bien assigné
- [x] Modifier/supprimer un cours en tant que son propriétaire → 200
- [x] Modifier/supprimer un cours d'un autre enseignant → 403