### PR TITLE
feat: invitation gestionnaire avec envoi mail

### DIFF
--- a/backend/app/Exceptions/Invitation/TokenDejaUtiliseException.php
+++ b/backend/app/Exceptions/Invitation/TokenDejaUtiliseException.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace App\Exceptions\Emargement;
+namespace App\Exceptions\Invitation;
 
 use Exception;
 use Illuminate\Http\JsonResponse;
 
-class JetonInvalideException extends Exception
+class TokenDejaUtiliseException extends Exception
 {
     public function __construct()
     {
-        parent::__construct('Jeton invalide.');
+        parent::__construct('Token déjà utilisé.');
     }
 
     public function render(): JsonResponse

--- a/backend/app/Exceptions/Invitation/TokenExpireException.php
+++ b/backend/app/Exceptions/Invitation/TokenExpireException.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace App\Exceptions\Emargement;
+namespace App\Exceptions\Invitation;
 
 use Exception;
 use Illuminate\Http\JsonResponse;
 
-class JetonInvalideException extends Exception
+class TokenExpireException extends Exception
 {
     public function __construct()
     {
-        parent::__construct('Jeton invalide.');
+        parent::__construct('Token d\'invitation expiré, veuillez demander une nouvelle invitation.');
     }
 
     public function render(): JsonResponse

--- a/backend/app/Http/Controllers/InvitationGestionnaireController.php
+++ b/backend/app/Http/Controllers/InvitationGestionnaireController.php
@@ -34,8 +34,7 @@ class InvitationGestionnaireController extends Controller
 
     public function annuler(InvitationGestionnaire $invitation)
     {
-
-        $this->invitGestionnaireService->supprimerInvitation($invitation->id);
+        $invitation->delete();
 
         return response()->noContent();
     }

--- a/backend/app/Http/Controllers/InvitationGestionnaireController.php
+++ b/backend/app/Http/Controllers/InvitationGestionnaireController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Exceptions\NonAutoriseException;
+use App\Models\InvitationGestionnaire;
+use App\Services\InvitationGestionnaireService;
+use Illuminate\Http\Request;
+
+class InvitationGestionnaireController extends Controller
+{
+    public function __construct(private InvitationGestionnaireService $invitGestionnaireService)
+    {
+    }
+
+    public function inviter(Request $request)
+    {
+        $request->validate([
+            'email' => 'required|email',
+        ]);
+
+        $invitation = $this->invitGestionnaireService->creerInvitation($request->email);
+
+        return response()->json($invitation, 201);
+    }
+
+    public function getInvitations()
+    {
+        $invitations = $this->invitGestionnaireService->getInvitations();
+
+        return response()->json($invitations);
+    }
+
+    public function annuler(InvitationGestionnaire $invitation)
+    {
+
+        $this->invitGestionnaireService->supprimerInvitation($invitation->id);
+
+        return response()->noContent();
+    }
+
+    public function inscrire(Request $request, string $token)
+    {
+        $data = $request->validate([
+            'nom' => 'required|string',
+            'prenom' => 'required|string',
+            'password' => 'required|string|min:8',
+        ]);
+
+        $tokenInscrit = $this->invitGestionnaireService->inscrireViaToken($token, $data);
+
+        return response()->json([
+            'message' => 'Inscription réussie.',
+            'token' => $tokenInscrit,
+        ], 201);
+    }
+
+    public function renvoyer(Request $request, string $token)
+    {
+        $invitation = InvitationGestionnaire::where('token', $token)->first();
+
+        if (! $invitation) {
+            throw new NonAutoriseException();
+        }
+
+        $this->invitGestionnaireService->creerInvitation($invitation->email);
+
+        return response()->json(['message' => 'Invitation renvoyée.']);
+    }
+
+    public function verifierToken(string $token)
+    {
+        $invitation = $this->invitGestionnaireService->validerToken($token);
+
+        return response()->json($invitation);
+    }
+}

--- a/backend/app/Http/Controllers/InvitationGestionnaireController.php
+++ b/backend/app/Http/Controllers/InvitationGestionnaireController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Exceptions\NonAutoriseException;
 use App\Http\Resources\InvitationResource;
 use App\Models\InvitationGestionnaire;
 use App\Services\InvitationGestionnaireService;
@@ -55,14 +54,8 @@ class InvitationGestionnaireController extends Controller
         ], 201);
     }
 
-    public function renvoyer(Request $request, string $token)
+    public function renvoyer(InvitationGestionnaire $invitation)
     {
-        $invitation = InvitationGestionnaire::where('token', $token)->first();
-
-        if (! $invitation) {
-            throw new NonAutoriseException();
-        }
-
         $this->invitGestionnaireService->creerInvitation($invitation->email);
 
         return response()->json(['message' => 'Invitation renvoyée.']);

--- a/backend/app/Http/Controllers/InvitationGestionnaireController.php
+++ b/backend/app/Http/Controllers/InvitationGestionnaireController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Exceptions\NonAutoriseException;
+use App\Http\Resources\InvitationResource;
 use App\Models\InvitationGestionnaire;
 use App\Services\InvitationGestionnaireService;
 use Illuminate\Http\Request;
@@ -28,7 +29,7 @@ class InvitationGestionnaireController extends Controller
     {
         $invitations = $this->invitGestionnaireService->getInvitations();
 
-        return response()->json($invitations);
+        return InvitationResource::collection($invitations);
     }
 
     public function annuler(InvitationGestionnaire $invitation)

--- a/backend/app/Http/Resources/InvitationResource.php
+++ b/backend/app/Http/Resources/InvitationResource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class InvitationResource extends JsonResource
+{
+    // Transforme la resource en un tableau.
+
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'email' => $this->email,
+            'expires_at' => $this->expires_at,
+            'used_at' => $this->used_at,
+        ];
+    }
+}

--- a/backend/app/Mail/InvitationGestionnaireEmail.php
+++ b/backend/app/Mail/InvitationGestionnaireEmail.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\InvitationGestionnaire;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class InvitationGestionnaireEmail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public string $lienInscription;
+
+    public function __construct(InvitationGestionnaire $invitation)
+    {
+        $this->lienInscription = config('app.frontend_url') . '/inscription/gestionnaire/' . $invitation->token;
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Invitation gestionnaire — Sygma',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.invitation_gestionnaire',
+        );
+    }
+
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/backend/app/Models/InvitationGestionnaire.php
+++ b/backend/app/Models/InvitationGestionnaire.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class InvitationGestionnaire extends Model
+{
+    use HasFactory;
+
+    protected $table = 'invitations_gestionnaire';
+
+    protected $fillable = [
+        'email',
+        'token',
+        'expires_at',
+        'used_at',
+    ];
+
+    protected $casts = [
+        'used_at' => 'datetime',
+        'expires_at' => 'datetime',
+    ];
+
+    public function estValide()
+    {
+        return $this->expires_at->isFuture() && ! $this->used_at;
+    }
+}

--- a/backend/app/Services/InvitationGestionnaireService.php
+++ b/backend/app/Services/InvitationGestionnaireService.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\Emargement\JetonInvalideException;
+use App\Exceptions\Invitation\TokenDejaUtiliseException;
+use App\Exceptions\Invitation\TokenExpireException;
+use App\Mail\InvitationGestionnaireEmail;
+use App\Models\InvitationGestionnaire;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+
+class InvitationGestionnaireService
+{
+    protected const DUREE_VALIDITE_INVITATION = 48; // en heures
+
+    public function creerInvitation(string $email): InvitationGestionnaire
+    {
+        $token = Str::random(32);
+        $expiresAt = Carbon::now()->addHours(self::DUREE_VALIDITE_INVITATION);
+
+        $invitation = InvitationGestionnaire::updateOrCreate(
+            ['email' => $email],
+            ['token' => $token, 'expires_at' => $expiresAt, 'used_at' => null]
+        );
+
+        Mail::to($email)->send(new InvitationGestionnaireEmail($invitation));
+
+        return $invitation;
+    }
+
+    public function validerToken(string $token): InvitationGestionnaire
+    {
+        $invitation = InvitationGestionnaire::where('token', $token)->first();
+
+        if (! $invitation) {
+            throw new JetonInvalideException();
+        }
+
+        if ($invitation->expires_at->isPast()) {
+            throw new TokenExpireException();
+        }
+
+        if ($invitation->used_at) {
+            throw new TokenDejaUtiliseException();
+        }
+
+        return $invitation;
+    }
+
+    public function inscrireViaToken(string $token, array $data): string
+    {
+        $invitation = $this->validerToken($token);
+
+        $user = User::create([
+            'nom' => $data['nom'],
+            'prenom' => $data['prenom'],
+            'email' => $invitation->email,
+            'password' => bcrypt($data['password']),
+        ]);
+
+        $user->assignRole('gestionnaire');
+
+        $invitation->used_at = Carbon::now();
+        $invitation->save();
+
+        return $user->createToken('api-token')->plainTextToken;
+    }
+
+    public function supprimerInvitation(int $id): void
+    {
+        $invitation = InvitationGestionnaire::where('id', $id)->first();
+
+        if ($invitation) {
+            $invitation->delete();
+        }
+    }
+
+    public function getInvitations(): Collection
+    {
+        return InvitationGestionnaire::orderBy('created_at', 'desc')->get();
+    }
+}

--- a/backend/app/Services/InvitationGestionnaireService.php
+++ b/backend/app/Services/InvitationGestionnaireService.php
@@ -9,7 +9,6 @@ use App\Mail\InvitationGestionnaireEmail;
 use App\Models\InvitationGestionnaire;
 use App\Models\User;
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 
@@ -79,8 +78,8 @@ class InvitationGestionnaireService
         }
     }
 
-    public function getInvitations(): Collection
+    public function getInvitations(int $perPage = 10)
     {
-        return InvitationGestionnaire::orderBy('created_at', 'desc')->get();
+        return InvitationGestionnaire::orderBy('created_at', 'desc')->paginate($perPage);
     }
 }

--- a/backend/app/Services/InvitationGestionnaireService.php
+++ b/backend/app/Services/InvitationGestionnaireService.php
@@ -69,15 +69,6 @@ class InvitationGestionnaireService
         return $user->createToken('api-token')->plainTextToken;
     }
 
-    public function supprimerInvitation(int $id): void
-    {
-        $invitation = InvitationGestionnaire::where('id', $id)->first();
-
-        if ($invitation) {
-            $invitation->delete();
-        }
-    }
-
     public function getInvitations(int $perPage = 10)
     {
         return InvitationGestionnaire::orderBy('created_at', 'desc')->paginate($perPage);

--- a/backend/database/factories/InvitationGestionnaireFactory.php
+++ b/backend/database/factories/InvitationGestionnaireFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\InvitationGestionnaire;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class InvitationGestionnaireFactory extends Factory
+{
+    protected $model = InvitationGestionnaire::class;
+
+    public function definition(): array
+    {
+        return [
+            'email' => $this->faker->unique()->safeEmail(),
+            'token' => Str::random(60),
+            'expires_at' => now()->addDays(7),
+            'used_at' => null,
+        ];
+    }
+
+    public function expiree(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'expires_at' => now()->subDays(1),
+        ]);
+    }
+
+    public function utilisee(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'used_at' => now(),
+        ]);
+    }
+}

--- a/backend/database/migrations/2026_04_16_090540_creer_table_invitations_gestionnaire.php
+++ b/backend/database/migrations/2026_04_16_090540_creer_table_invitations_gestionnaire.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('invitations_gestionnaire', function (Blueprint $table) {
             $table->id();
-            $table->string('email');
+            $table->string('email')->unique();
             $table->string('token')->unique();
             $table->timestamp('expires_at');
             $table->timestamp(('used_at'))->nullable();

--- a/backend/database/migrations/2026_04_16_090540_creer_table_invitations_gestionnaire.php
+++ b/backend/database/migrations/2026_04_16_090540_creer_table_invitations_gestionnaire.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('invitations_gestionnaire', function (Blueprint $table) {
+            $table->id();
+            $table->string('email');
+            $table->string('token')->unique();
+            $table->timestamp('expires_at');
+            $table->timestamp(('used_at'))->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('invitations_gestionnaire');
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\Cours;
 use App\Models\Groupe;
 use App\Models\Inscription;
+use App\Models\InvitationGestionnaire;
 use App\Models\Presence;
 use App\Models\Seance;
 use App\Models\SessionEmargement;
@@ -47,6 +48,22 @@ class DatabaseSeeder extends Seeder
             'password' => Hash::make('sygma'),
             'premiere_connexion' => false,
         ])->assignRole('gestionnaire');
+
+        // Invitations gestionnaire
+        $this->command->info('Création des invitations gestionnaire...');
+        InvitationGestionnaire::firstOrCreate(['email' => 'invite@sygma.com'], [
+            'token' => 'abc123token',
+            'expires_at' => now()->addDays(7),
+        ]);
+        InvitationGestionnaire::firstOrCreate(['email' => 'expired@sygma.com'], [
+            'token' => 'expiredtoken',
+            'expires_at' => now()->subDays(1),
+        ]);
+        InvitationGestionnaire::firstOrCreate(['email' => 'used@sygma.com'], [
+            'token' => 'usedtoken',
+            'expires_at' => now()->addDays(7),
+            'used_at' => now(),
+        ]);
 
         // 3. Enseignants — enseignant@sygma.com est exclu du pool aléatoire
         $this->command->info('Création des enseignants...');

--- a/backend/resources/views/emails/invitation_gestionnaire.blade.php
+++ b/backend/resources/views/emails/invitation_gestionnaire.blade.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Invitation gestionnaire — Sygma</title>
+</head>
+<body style="font-family: sans-serif; padding: 32px;">
+    <h2>Vous avez été invité à rejoindre Sygma en tant que gestionnaire</h2>
+    <p>Cliquez sur le lien ci-dessous pour créer votre compte :</p>
+    <p>
+        <a href="{{ $lienInscription }}" style="background:#4f46e5;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;">
+            Créer mon compte
+        </a>
+    </p>
+    <p style="color:#888;font-size:13px;">Ce lien expire dans 48 heures. Si vous n'attendiez pas cette invitation, ignorez cet email.</p>
+</body>
+</html>

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\ControllerCours;
 use App\Http\Controllers\EmargementController;
 use App\Http\Controllers\ExportController;
 use App\Http\Controllers\GoogleAuthController;
+use App\Http\Controllers\InvitationGestionnaireController;
 use App\Http\Controllers\PresenceController;
 use App\Http\Controllers\SeanceController;
 use App\Http\Controllers\UserController;
@@ -17,6 +18,8 @@ Route::post('register', [AuthController::class, 'register']);
 Route::get('email/verify/{token}', [AuthController::class, 'verifierEmail']);
 Route::post('auth/google/finaliser', [GoogleAuthController::class, 'finaliser']);
 Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);
+Route::post('/invitations/gestionnaire/{token}', [InvitationGestionnaireController::class, 'inscrire']);
+Route::get('/invitations/gestionnaire/{token}', [InvitationGestionnaireController::class, 'verifierToken']);
 
 /*
 * Enseignants
@@ -28,6 +31,17 @@ Route::middleware('auth:sanctum', 'role:enseignant|gestionnaire')->group(functio
     Route::post('/sessions-emargement', [EmargementController::class, 'demarrerSession']);
     Route::post('/sessions-emargement/{session}/refresh', [EmargementController::class, 'rafraichirJeton']);
     Route::post('/sessions-emargement/{session}/cloturer', [EmargementController::class, 'cloturerSession']);
+});
+
+/*
+* Gestionnaires
+*
+*/
+Route::middleware('auth:sanctum', 'role:gestionnaire')->group(function () {
+    Route::post('/gestionnaire/invitations', [InvitationGestionnaireController::class, 'inviter']);
+    Route::post('/gestionnaire/invitations/{token}/renvoyer', [InvitationGestionnaireController::class, 'renvoyer']);
+    Route::get('/gestionnaire/invitations', [InvitationGestionnaireController::class, 'getInvitations']);
+    Route::delete('/gestionnaire/invitations/{invitation}', [InvitationGestionnaireController::class, 'annuler']);
 });
 
 /*

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -39,7 +39,7 @@ Route::middleware('auth:sanctum', 'role:enseignant|gestionnaire')->group(functio
 */
 Route::middleware('auth:sanctum', 'role:gestionnaire')->group(function () {
     Route::post('/gestionnaire/invitations', [InvitationGestionnaireController::class, 'inviter']);
-    Route::post('/gestionnaire/invitations/{token}/renvoyer', [InvitationGestionnaireController::class, 'renvoyer']);
+    Route::post('/gestionnaire/invitations/{invitation}/renvoyer', [InvitationGestionnaireController::class, 'renvoyer']);
     Route::get('/gestionnaire/invitations', [InvitationGestionnaireController::class, 'getInvitations']);
     Route::delete('/gestionnaire/invitations/{invitation}', [InvitationGestionnaireController::class, 'annuler']);
 });

--- a/backend/tests/Feature/InvitationGestionnaireTest.php
+++ b/backend/tests/Feature/InvitationGestionnaireTest.php
@@ -293,26 +293,25 @@ class InvitationGestionnaireTest extends FeatureTestCase
         Mail::fake();
 
         $gestionnaire = $this->creerGestionnaire();
-        $token = Str::random(32);
 
-        InvitationGestionnaire::create([
+        $invitation = InvitationGestionnaire::create([
             'email' => 'a@test.fr',
-            'token' => $token,
+            'token' => Str::random(32),
             'expires_at' => now()->addHours(48),
         ]);
 
-        $response = $this->actingAs($gestionnaire)->postJson("/api/gestionnaire/invitations/{$token}/renvoyer");
+        $response = $this->actingAs($gestionnaire)->postJson("/api/gestionnaire/invitations/{$invitation->id}/renvoyer");
 
         $response->assertStatus(200)->assertJsonFragment(['message' => 'Invitation renvoyée.']);
         Mail::assertSent(InvitationGestionnaireEmail::class, fn ($mail) => $mail->hasTo('a@test.fr'));
     }
 
-    public function test_renvoyer_token_inexistant_retourne_erreur(): void
+    public function test_renvoyer_id_inexistant_retourne_erreur(): void
     {
         $gestionnaire = $this->creerGestionnaire();
 
-        $response = $this->actingAs($gestionnaire)->postJson('/api/gestionnaire/invitations/token-inexistant/renvoyer');
+        $response = $this->actingAs($gestionnaire)->postJson('/api/gestionnaire/invitations/99999/renvoyer');
 
-        $response->assertStatus(403);
+        $response->assertStatus(404);
     }
 }

--- a/backend/tests/Feature/InvitationGestionnaireTest.php
+++ b/backend/tests/Feature/InvitationGestionnaireTest.php
@@ -1,0 +1,318 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\InvitationGestionnaireEmail;
+use App\Models\InvitationGestionnaire;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+
+class InvitationGestionnaireTest extends FeatureTestCase
+{
+    private function creerGestionnaire(): User
+    {
+        $gestionnaire = User::factory()->create();
+        $gestionnaire->assignRole('gestionnaire');
+
+        return $gestionnaire;
+    }
+
+    // POST /gestionnaire/invitations
+
+    public function test_gestionnaire_peut_inviter_un_email(): void
+    {
+        Mail::fake();
+
+        $gestionnaire = $this->creerGestionnaire();
+
+        $response = $this->actingAs($gestionnaire)->postJson('/api/gestionnaire/invitations', [
+            'email' => 'nouveau@test.fr',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('invitations_gestionnaire', ['email' => 'nouveau@test.fr']);
+        Mail::assertSent(InvitationGestionnaireEmail::class, fn ($mail) => $mail->hasTo('nouveau@test.fr'));
+    }
+
+    public function test_inviter_sans_email_retourne_422(): void
+    {
+        $gestionnaire = $this->creerGestionnaire();
+
+        $response = $this->actingAs($gestionnaire)->postJson('/api/gestionnaire/invitations', []);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_inviter_email_invalide_retourne_422(): void
+    {
+        $gestionnaire = $this->creerGestionnaire();
+
+        $response = $this->actingAs($gestionnaire)->postJson('/api/gestionnaire/invitations', [
+            'email' => 'pas-un-email',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_non_authentifie_ne_peut_pas_inviter(): void
+    {
+        $response = $this->postJson('/api/gestionnaire/invitations', [
+            'email' => 'nouveau@test.fr',
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_etudiant_ne_peut_pas_inviter(): void
+    {
+        $etudiant = User::factory()->create();
+        $etudiant->assignRole('etudiant');
+
+        $response = $this->actingAs($etudiant)->postJson('/api/gestionnaire/invitations', [
+            'email' => 'nouveau@test.fr',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_reinviter_meme_email_remplace_invitation(): void
+    {
+        Mail::fake();
+
+        $gestionnaire = $this->creerGestionnaire();
+
+        $this->actingAs($gestionnaire)->postJson('/api/gestionnaire/invitations', [
+            'email' => 'nouveau@test.fr',
+        ]);
+
+        $this->actingAs($gestionnaire)->postJson('/api/gestionnaire/invitations', [
+            'email' => 'nouveau@test.fr',
+        ]);
+
+        $this->assertDatabaseCount('invitations_gestionnaire', 1);
+    }
+
+    // GET /gestionnaire/invitations
+
+    public function test_gestionnaire_peut_lister_invitations(): void
+    {
+        $gestionnaire = $this->creerGestionnaire();
+
+        InvitationGestionnaire::create([
+            'email' => 'a@test.fr',
+            'token' => Str::random(32),
+            'expires_at' => now()->addHours(48),
+        ]);
+
+        $response = $this->actingAs($gestionnaire)->getJson('/api/gestionnaire/invitations');
+
+        $response->assertStatus(200)->assertJsonCount(1);
+    }
+
+    // DELETE /gestionnaire/invitations/{invitation}
+
+    public function test_gestionnaire_peut_annuler_invitation(): void
+    {
+        $gestionnaire = $this->creerGestionnaire();
+
+        $invitation = InvitationGestionnaire::create([
+            'email' => 'a@test.fr',
+            'token' => Str::random(32),
+            'expires_at' => now()->addHours(48),
+        ]);
+
+        $response = $this->actingAs($gestionnaire)->deleteJson("/api/gestionnaire/invitations/{$invitation->id}");
+
+        $response->assertStatus(204);
+        $this->assertDatabaseMissing('invitations_gestionnaire', ['id' => $invitation->id]);
+    }
+
+    // GET /invitations/gestionnaire/{token}
+
+    public function test_token_valide_retourne_invitation(): void
+    {
+        $token = Str::random(32);
+
+        InvitationGestionnaire::create([
+            'email' => 'a@test.fr',
+            'token' => $token,
+            'expires_at' => now()->addHours(48),
+        ]);
+
+        $response = $this->getJson("/api/invitations/gestionnaire/{$token}");
+
+        $response->assertStatus(200)->assertJsonFragment(['email' => 'a@test.fr']);
+    }
+
+    public function test_token_inexistant_retourne_erreur(): void
+    {
+        $response = $this->getJson('/api/invitations/gestionnaire/token-inexistant');
+
+        $response->assertStatus(422);
+    }
+
+    public function test_token_expire_retourne_erreur(): void
+    {
+        $token = Str::random(32);
+
+        InvitationGestionnaire::create([
+            'email' => 'a@test.fr',
+            'token' => $token,
+            'expires_at' => now()->subHours(1),
+        ]);
+
+        $response = $this->getJson("/api/invitations/gestionnaire/{$token}");
+
+        $response->assertStatus(422);
+    }
+
+    public function test_token_deja_utilise_retourne_erreur(): void
+    {
+        $token = Str::random(32);
+
+        InvitationGestionnaire::create([
+            'email' => 'a@test.fr',
+            'token' => $token,
+            'expires_at' => now()->addHours(48),
+            'used_at' => now(),
+        ]);
+
+        $response = $this->getJson("/api/invitations/gestionnaire/{$token}");
+
+        $response->assertStatus(422);
+    }
+
+    // POST /invitations/gestionnaire/{token}
+
+    public function test_inscription_via_token_valide_cree_gestionnaire(): void
+    {
+        $token = Str::random(32);
+
+        InvitationGestionnaire::create([
+            'email' => 'nouveau@test.fr',
+            'token' => $token,
+            'expires_at' => now()->addHours(48),
+        ]);
+
+        $response = $this->postJson("/api/invitations/gestionnaire/{$token}", [
+            'nom' => 'Dupont',
+            'prenom' => 'Jean',
+            'password' => 'motdepasse123',
+        ]);
+
+        $response->assertStatus(201)->assertJsonStructure(['message', 'token']);
+
+        $user = User::where('email', 'nouveau@test.fr')->first();
+        $this->assertNotNull($user);
+        $this->assertTrue($user->hasRole('gestionnaire'));
+
+        $invitation = InvitationGestionnaire::where('token', $token)->first();
+        $this->assertNotNull($invitation->used_at);
+    }
+
+    public function test_inscription_sans_nom_retourne_422(): void
+    {
+        $token = Str::random(32);
+
+        InvitationGestionnaire::create([
+            'email' => 'nouveau@test.fr',
+            'token' => $token,
+            'expires_at' => now()->addHours(48),
+        ]);
+
+        $response = $this->postJson("/api/invitations/gestionnaire/{$token}", [
+            'password' => 'motdepasse123',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_inscription_mot_de_passe_trop_court_retourne_422(): void
+    {
+        $token = Str::random(32);
+
+        InvitationGestionnaire::create([
+            'email' => 'nouveau@test.fr',
+            'token' => $token,
+            'expires_at' => now()->addHours(48),
+        ]);
+
+        $response = $this->postJson("/api/invitations/gestionnaire/{$token}", [
+            'nom' => 'Dupont',
+            'prenom' => 'Jean',
+            'password' => 'court',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_inscription_token_expire_retourne_erreur(): void
+    {
+        $token = Str::random(32);
+
+        InvitationGestionnaire::create([
+            'email' => 'nouveau@test.fr',
+            'token' => $token,
+            'expires_at' => now()->subHours(1),
+        ]);
+
+        $response = $this->postJson("/api/invitations/gestionnaire/{$token}", [
+            'nom' => 'Dupont',
+            'prenom' => 'Jean',
+            'password' => 'motdepasse123',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_inscription_token_deja_utilise_retourne_erreur(): void
+    {
+        $token = Str::random(32);
+
+        InvitationGestionnaire::create([
+            'email' => 'nouveau@test.fr',
+            'token' => $token,
+            'expires_at' => now()->addHours(48),
+            'used_at' => now(),
+        ]);
+
+        $response = $this->postJson("/api/invitations/gestionnaire/{$token}", [
+            'nom' => 'Dupont',
+            'prenom' => 'Jean',
+            'password' => 'motdepasse123',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    // POST /gestionnaire/invitations/{token}/renvoyer
+
+    public function test_gestionnaire_peut_renvoyer_invitation(): void
+    {
+        Mail::fake();
+
+        $gestionnaire = $this->creerGestionnaire();
+        $token = Str::random(32);
+
+        InvitationGestionnaire::create([
+            'email' => 'a@test.fr',
+            'token' => $token,
+            'expires_at' => now()->addHours(48),
+        ]);
+
+        $response = $this->actingAs($gestionnaire)->postJson("/api/gestionnaire/invitations/{$token}/renvoyer");
+
+        $response->assertStatus(200)->assertJsonFragment(['message' => 'Invitation renvoyée.']);
+        Mail::assertSent(InvitationGestionnaireEmail::class, fn ($mail) => $mail->hasTo('a@test.fr'));
+    }
+
+    public function test_renvoyer_token_inexistant_retourne_erreur(): void
+    {
+        $gestionnaire = $this->creerGestionnaire();
+
+        $response = $this->actingAs($gestionnaire)->postJson('/api/gestionnaire/invitations/token-inexistant/renvoyer');
+
+        $response->assertStatus(403);
+    }
+}

--- a/backend/tests/Feature/InvitationGestionnaireTest.php
+++ b/backend/tests/Feature/InvitationGestionnaireTest.php
@@ -107,7 +107,7 @@ class InvitationGestionnaireTest extends FeatureTestCase
 
         $response = $this->actingAs($gestionnaire)->getJson('/api/gestionnaire/invitations');
 
-        $response->assertStatus(200)->assertJsonCount(1);
+        $response->assertStatus(200)->assertJsonCount(1, 'data');
     }
 
     // DELETE /gestionnaire/invitations/{invitation}

--- a/docs/api_doc.md
+++ b/docs/api_doc.md
@@ -31,6 +31,13 @@ Ce document est destiné aux développeurs frontend. Il décrit les endpoints di
   - [Créer un cours](#créer-un-cours)
   - [Modifier un cours](#modifier-un-cours)
   - [Supprimer un cours](#supprimer-un-cours)
+- [Invitations gestionnaire](#invitations-gestionnaire)
+  - [Inviter un gestionnaire](#inviter-un-gestionnaire)
+  - [Lister les invitations](#lister-les-invitations)
+  - [Annuler une invitation](#annuler-une-invitation)
+  - [Renvoyer une invitation](#renvoyer-une-invitation)
+  - [Vérifier un token](#vérifier-un-token)
+  - [S'inscrire via token](#sinscrire-via-token)
 - [Export de donner](#export-de-donner)
   - [Récupérer les sessions par date](#récupérer-les-sessions-par-date)
   - [Récupérer les absences du jour](#récupérer-les-absences-du-jour)
@@ -395,6 +402,155 @@ DELETE /Cours/Supprimer/{id}
 
 **Réponse 200** — `"Le cours a bien été supprimé"`
 **Réponse 404** — `"Le cours n'a pas été trouvé"`
+
+---
+
+## Invitations gestionnaire
+
+### Inviter un gestionnaire
+
+```
+POST /gestionnaire/invitations
+```
+
+**Auth requise** : gestionnaire
+
+**Corps (JSON)**
+
+| Champ   | Type   | Requis | Description                  |
+| ------- | ------ | ------ | ---------------------------- |
+| `email` | string | oui    | Email de la personne invitée |
+
+**Réponse 201** — invitation créée (ou réinitialisée si l'email existait déjà).
+
+Un email contenant un lien d'inscription valable **48 heures** est envoyé automatiquement.
+
+**Erreurs possibles**
+
+| Code | Cause |
+| ---- | ----- |
+| 422  | Email manquant ou invalide |
+| 401  | Non authentifié |
+| 403  | Rôle insuffisant |
+
+---
+
+### Lister les invitations
+
+```
+GET /gestionnaire/invitations
+```
+
+**Auth requise** : gestionnaire
+
+**Réponse 200** — tableau des invitations, ordre anti-chronologique.
+
+```json
+[
+  {
+    "id": 1,
+    "email": "nouveau@example.fr",
+    "token": "abc123...",
+    "expires_at": "2026-04-18T09:00:00.000000Z",
+    "used_at": null,
+    "created_at": "2026-04-16T09:00:00.000000Z"
+  }
+]
+```
+
+---
+
+### Annuler une invitation
+
+```
+DELETE /gestionnaire/invitations/{id}
+```
+
+**Auth requise** : gestionnaire
+
+**Réponse 204** — aucun contenu.
+
+---
+
+### Renvoyer une invitation
+
+```
+POST /gestionnaire/invitations/{token}/renvoyer
+```
+
+**Auth requise** : gestionnaire
+
+Régénère le token et la date d'expiration, renvoie l'email.
+
+**Réponse 200**
+
+```json
+{ "message": "Invitation renvoyée." }
+```
+
+**Erreurs possibles**
+
+| Code | Cause |
+| ---- | ----- |
+| 403  | Token introuvable |
+
+---
+
+### Vérifier un token
+
+```
+GET /invitations/gestionnaire/{token}
+```
+
+**Auth non requise** — utilisé par la page d'inscription frontend pour valider le lien avant affichage du formulaire.
+
+**Réponse 200** — retourne l'invitation (dont l'email pré-rempli).
+
+**Erreurs possibles**
+
+| Code | Message | Cause |
+| ---- | ------- | ----- |
+| 422  | `Jeton invalide.` | Token inexistant |
+| 422  | `Token d'invitation expiré...` | Token expiré (> 48h) |
+| 422  | `Token déjà utilisé.` | Inscription déjà effectuée |
+
+---
+
+### S'inscrire via token
+
+```
+POST /invitations/gestionnaire/{token}
+```
+
+**Auth non requise** — point d'entrée public pour finaliser la création de compte.
+
+**Corps (JSON)**
+
+| Champ      | Type   | Requis | Description          |
+| ---------- | ------ | ------ | -------------------- |
+| `nom`      | string | oui    | Nom de famille       |
+| `prenom`   | string | oui    | Prénom               |
+| `password` | string | oui    | Mot de passe (≥ 8 caractères) |
+
+**Réponse 201**
+
+```json
+{
+  "message": "Inscription réussie.",
+  "token": "<sanctum-token>"
+}
+```
+
+Le compte est créé avec le rôle `gestionnaire`. L'invitation est marquée comme utilisée (`used_at`).
+
+**Erreurs possibles**
+
+| Code | Message | Cause |
+| ---- | ------- | ----- |
+| 422  | `Jeton invalide.` | Token inexistant |
+| 422  | `Token d'invitation expiré...` | Token expiré |
+| 422  | `Token déjà utilisé.` | Invitation déjà consommée |
+| 422  | Erreurs de validation | Champs manquants ou mot de passe trop court |
 
 ---
 

--- a/docs/api_doc.md
+++ b/docs/api_doc.md
@@ -443,19 +443,23 @@ GET /gestionnaire/invitations
 
 **Auth requise** : gestionnaire
 
-**Réponse 200** — tableau des invitations, ordre anti-chronologique.
+**Réponse 200** — liste paginée des invitations, ordre anti-chronologique.
 
 ```json
-[
-  {
-    "id": 1,
-    "email": "nouveau@example.fr",
-    "token": "abc123...",
-    "expires_at": "2026-04-18T09:00:00.000000Z",
-    "used_at": null,
-    "created_at": "2026-04-16T09:00:00.000000Z"
-  }
-]
+{
+  "data": [
+    {
+      "id": 1,
+      "email": "nouveau@example.fr",
+      "expires_at": "2026-04-18T09:00:00.000000Z",
+      "used_at": null
+    }
+  ],
+  "current_page": 1,
+  "last_page": 1,
+  "per_page": 10,
+  "total": 1
+}
 ```
 
 ---
@@ -475,7 +479,7 @@ DELETE /gestionnaire/invitations/{id}
 ### Renvoyer une invitation
 
 ```
-POST /gestionnaire/invitations/{token}/renvoyer
+POST /gestionnaire/invitations/{id}/renvoyer
 ```
 
 **Auth requise** : gestionnaire
@@ -492,7 +496,7 @@ Régénère le token et la date d'expiration, renvoie l'email.
 
 | Code | Cause |
 | ---- | ----- |
-| 403  | Token introuvable |
+| 404  | Invitation introuvable |
 
 ---
 

--- a/docs/doc_technique.md
+++ b/docs/doc_technique.md
@@ -86,13 +86,14 @@ Le schéma complet (MCD/MLD) est disponible dans `docs/specs/MCD/`.
 
 | Table | Description |
 |---|---|
-| `users` | Étudiants et enseignants, avec rôles Spatie et `google_id` pour OAuth |
+| `users` | Étudiants, enseignants et gestionnaires, avec rôles Spatie et `google_id` pour OAuth |
 | `groupes` | Groupes d'étudiants |
 | `cours` | Matières enseignées |
 | `seances` | Séances planifiées (`cours_id`, `enseignant_id`, `groupe_id`, `debut_a`, `fin_a`, `salle`) |
 | `inscriptions` | Inscription étudiant ↔ cours |
 | `sessions_emargement` | Session d'émargement liée à une séance (`jeton`, `jeton_expire_a`, `cloture_a`, `is_methode_qr`, lat/lon) |
 | `presences` | Présence enregistrée (`session_id`, `etudiant_id`, `statut`, `scanne_a`, lat/lon) |
+| `invitations_gestionnaire` | Invitation en attente d'un gestionnaire (`email`, `token`, `expires_at`, `used_at`) |
 
 ---
 
@@ -111,6 +112,21 @@ La logique métier est isolée dans des classes de service, séparée des contr�
 | `enregistrerPresence(SessionEmargement, User)` | Enregistre une présence manuelle |
 | `rafraichirJeton(SessionEmargement)` | Rotation du jeton (nouveau jeton + 20s d'expiration) |
 | `cloturerSession(SessionEmargement)` | Met `cloture_a = now()` (session inactive si `cloture_a` non null) |
+
+**`InvitationGestionnaireService`** — gestion du cycle de vie des invitations gestionnaire :
+
+| Méthode | Rôle |
+|---|---|
+| `creerInvitation(email)` | Crée ou réinitialise une invitation (token 32 car., expiration 48h), envoie l'email |
+| `validerToken(token)` | Vérifie qu'un token existe, n'est pas expiré et n'a pas déjà été utilisé |
+| `inscrireViaToken(token, data)` | Crée le compte gestionnaire, assigne le rôle, marque l'invitation comme utilisée |
+| `supprimerInvitation(id)` | Supprime une invitation en attente |
+| `getInvitations()` | Liste toutes les invitations (ordre anti-chronologique) |
+
+**Règles métier notables :**
+- Durée de validité d'une invitation : **48 heures** (constante `DUREE_VALIDITE_INVITATION`)
+- `updateOrCreate` sur l'email : réinviter un même email renouvelle le token sans créer de doublon
+- L'inscription via token consomme l'invitation (`used_at = now()`) — elle ne peut être utilisée qu'une fois
 
 **`SeanceService`** — gestion des séances :
 
@@ -140,6 +156,9 @@ app/Exceptions/
 │   ├── EtudiantNonInscritException.php
 │   ├── JetonExpireException.php
 │   └── JetonInvalideException.php
+├── Invitation/
+│   ├── TokenExpireException.php
+│   └── TokenDejaUtiliseException.php
 └── Seance/
     ├── ConflitSeanceException.php
     ├── SalleOccupeeException.php
@@ -225,6 +244,7 @@ Ils tournent sur une base PostgreSQL dédiée (`sygma_test`), isolée de la base
 | `SessionEmargementTest.php` | Tests des routes d'émargement (démarrage, clôture, statut, présence manuelle) |
 | `EmargementSecurityTest.php` | Tests spécifiques sur les autorisations d'émargement |
 | `GoogleAuthTest.php` | Tests du cycle d'authentification Google OAuth |
+| `InvitationGestionnaireTest.php` | Tests du flux d'invitation gestionnaire (inviter, lister, annuler, vérifier token, s'inscrire, renvoyer — envoi mail inclus) |
 
 **Lancer les tests :**
 


### PR DESCRIPTION
## Résumé

- Flux complet d'invitation gestionnaire : inviter, vérifier token, s'inscrire, renvoyer, annuler
- Envoi automatique d'un email (Mailpit) à chaque invitation/renvoi via `InvitationGestionnaireEmail`
- Fix PSR-4 : `JetonExpireException.php` renommé en `TokenExpireException.php`
- Fix inscription : champs `nom`/`prenom` alignés avec le modèle `User`

## Tests

- 17 cas Feature couvrant tous les endpoints et cas d'erreur (token expiré, déjà utilisé, inexistant, droits manquants)
- `Mail::assertSent` vérifie l'envoi effectif du mail sur inviter et renvoyer