### PR TITLE
fix: page blanche Safari en mode mobile ngrok

### DIFF
--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -28,7 +28,7 @@ class DatabaseSeeder extends Seeder
      * Ce que voit enseignant@sygma.com :
      *   - 4 cours × 3 séances passées (avec émargement clôturé + présences)
      *   - 4 cours × 2 séances à venir
-     *   - 1 séance en cours sans session démarrée (prête pour la démo)
+     *   - 1 séance en cours avec session active + 1 présence enregistrée (etudiant@sygma.com)
      *
      * Ce que voit etudiant@sygma.com :
      *   - Les mêmes séances que son groupe (groupeDemo)
@@ -76,7 +76,7 @@ class DatabaseSeeder extends Seeder
         $enseignantFixe->assignRole('enseignant');
 
         $autresEnseignants = User::factory(4)->enseignant()->create();
-        $tousLesEnseignants = $autresEnseignants->prepend($enseignantFixe);
+        $tousLesEnseignants = collect([$enseignantFixe])->concat($autresEnseignants);
 
         // 4. Cours
         $this->command->info('Création des cours...');
@@ -245,14 +245,26 @@ class DatabaseSeeder extends Seeder
             $q->whereHas('utilisateur', fn ($u) => $u->where('groupe_id', $groupeDemo->id));
         })->inRandomOrder()->first() ?? $cours->first();
 
-        Seance::factory()->create([
+        $seanceDemo = Seance::factory()->create([
             'cours_id' => $coursDemo->id,
             'groupe_id' => $groupeDemo->id,
             'enseignant_id' => $enseignantFixe->id,
             'debut_a' => now()->subMinutes(30),
             'fin_a' => now()->addMinutes(90),
         ]);
-        $this->command->info('-> Séance de démo créée (en cours, sans session).');
+
+        $sessionDemo = SessionEmargement::factory()->create([
+            'seance_id' => $seanceDemo->id,
+            'jeton_expire_a' => now()->addMinutes(10),
+        ]);
+
+        $etudiantFixe = User::where('email', 'etudiant@sygma.com')->first();
+        Presence::factory()->create([
+            'session_emargement_id' => $sessionDemo->id,
+            'etudiant_id' => $etudiantFixe->id,
+        ]);
+
+        $this->command->info('-> Séance de démo créée (en cours, avec session + 1 présence enregistrée pour etudiant@sygma.com).');
 
         $this->command->info('');
         $this->command->info('✓ Comptes de test :');

--- a/docker-compose.mobile.yml
+++ b/docker-compose.mobile.yml
@@ -1,0 +1,3 @@
+services:
+  frontend:
+    command: sh -c "npm run build && npm run preview"

--- a/docs/doc_technique.md
+++ b/docs/doc_technique.md
@@ -258,84 +258,19 @@ make test
 
 ### Architecture
 
-Le frontend Vite est configuré comme **proxy inverse** vers le backend :
-
-```mermaid
-flowchart LR
-    A["Téléphone"]
-    B["ngrok\ntunnel HTTPS"]
-    C["Vite\nport 3000"]
-    D["Backend Laravel\nport 8000"]
-
-    A -- "HTTPS" --> B
-    B --> C
-    C -- "/api/*" --> D
-
-    style A fill:#dbeafe,stroke:#93c5fd,color:#1e3a5f
-    style B fill:#fce7f3,stroke:#f9a8d4,color:#500724
-    style C fill:#d1fae5,stroke:#6ee7b7,color:#064e3b
-    style D fill:#fef9c3,stroke:#fde047,color:#713f12
-```
-
-Tous les appels API passent par Vite, qui les transfère au backend via le réseau Docker interne (`http://backend:8000`). Le téléphone ne communique qu'avec un seul serveur, ce qui évite les problèmes CORS et la nécessité de plusieurs tunnels.
-
-### Configuration
-
-- `VITE_API_URL=/api` dans `frontend/.env` — URL relative, fonctionne sur tous les environnements
-- Proxy déclaré dans `vite.config.js` : `/api` → `http://backend:8000`
-- `allowedHosts: true` dans `vite.config.js` pour autoriser les domaines ngrok
-
-### Lancer les tests mobiles
-
-**Prérequis (une seule fois) :**
-```bash
-ngrok config add-authtoken <ton_token>  # compte gratuit sur dashboard.ngrok.com
-```
-
-**Workflow :**
-```bash
-make mobile       # lance ngrok, affiche l'URL + QR code à scanner
-# tester sur le téléphone...
-make mobile-stop  # arrête ngrok
-```
-
-`make mobile` :
-1. Démarre ngrok sur le port 3000 (tunnel HTTPS)
-2. Récupère l'URL publique via l'API locale ngrok
-3. Affiche l'URL et un QR code à scanner directement dans le terminal
-
-### Fichiers concernés
-
-| Fichier | Rôle |
-|---|---|
-| `ngrok.yml` | Config du tunnel ngrok (port 3000) |
-| `scripts/mobile.sh` | Script d'automatisation ngrok |
-| `scripts/mobile-stop.sh` | Arrêt ngrok |
-| `frontend/.env` | `VITE_API_URL=/api` |
-
----
-
-### Mode démo mobile avec Google Auth
-
-Par défaut, Google Auth est configuré pour fonctionner en local (`localhost`). Pour une démonstration sur mobile (ngrok), un script dédié switche la configuration sans modifier manuellement le `.env`.
-
-#### Pourquoi un script séparé
-
-Le callback Google OAuth doit pointer vers une URL publique. En mode local, il pointe vers `http://localhost:8000/auth/google/callback`. Sur mobile via ngrok, il faut que ce callback soit accessible depuis Internet.
-
-La solution exploite le **proxy Vite déjà en place** : le callback Google passe par le tunnel ngrok frontend (port 3000), qui le transfère au backend via le proxy interne. Un seul tunnel ngrok suffit.
+Le frontend est exposé via un tunnel ngrok HTTPS et sert de proxy inverse vers le backend :
 
 ```mermaid
 flowchart LR
     A["Téléphone"]
     B["ngrok\nbullpen-unafraid-mutual.ngrok-free.dev"]
-    C["Vite\nport 3000"]
+    C["Vite / preview\nport 3000"]
     D["Backend Laravel\nport 8000"]
     E["Google OAuth"]
 
     A -- "HTTPS" --> B
     B --> C
-    C -- "/auth/google/callback" --> D
+    C -- "/api/*\n/auth/google/callback" --> D
     E -- "redirect callback" --> B
 
     style A fill:#dbeafe,stroke:#93c5fd,color:#1e3a5f
@@ -345,37 +280,65 @@ flowchart LR
     style E fill:#ede9fe,stroke:#c4b5fd,color:#3b0764
 ```
 
-#### Prérequis (une seule fois)
+Tous les appels API et callbacks OAuth passent par le proxy Vite, qui les transfère au backend via le réseau Docker interne (`http://backend:8000`). Un seul tunnel ngrok suffit.
 
-Enregistrer l'URI de callback ngrok dans [Google Cloud Console](https://console.cloud.google.com) → APIs & Services → Credentials → OAuth 2.0 Client → **Authorized redirect URIs** :
+### Configuration
 
+- `VITE_API_URL=/api` dans `frontend/.env` — URL relative, fonctionne sur tous les environnements
+- Proxy déclaré dans `vite.config.js` : `/api` et `/auth` → `http://backend:8000`
+- `allowedHosts: true` dans `vite.config.js` pour autoriser les domaines ngrok
+- Domaine ngrok fixe configuré dans `ngrok.yml` : `bullpen-unafraid-mutual.ngrok-free.dev`
+
+### Prérequis (une seule fois)
+
+1. Configurer l'authtoken ngrok :
+```bash
+ngrok config add-authtoken <ton_token>  # compte gratuit sur dashboard.ngrok.com
+```
+
+2. Enregistrer l'URI de callback dans [Google Cloud Console](https://console.cloud.google.com) → APIs & Services → Credentials → OAuth 2.0 Client → **Authorized redirect URIs** :
 ```
 https://bullpen-unafraid-mutual.ngrok-free.dev/auth/google/callback
 ```
 
-#### Workflow
+### Workflow
 
 ```bash
-make demo-start   # met à jour .env, redémarre le backend, lance ngrok + QR code
-# démonstration sur mobile...
-make demo-stop    # restaure .env localhost, redémarre le backend, arrête ngrok
+make mobile       # configure, build le frontend, lance ngrok + QR code
+# tester sur le téléphone...
+make mobile-stop  # restaure la configuration locale et repasse en mode dev
 ```
 
-`make demo-start` modifie automatiquement deux variables dans `backend/.env` :
+`make mobile` effectue dans l'ordre :
+1. Démarre ngrok (domaine fixe `bullpen-unafraid-mutual.ngrok-free.dev`, port 3000)
+2. Met à jour `backend/.env` avec toutes les variables nécessaires
+3. Redémarre le backend pour recharger `.env`
+4. Build le frontend en mode production et le démarre en mode preview (`docker-compose.mobile.yml`)
+5. Affiche l'URL et un QR code à scanner dans le terminal
 
-| Variable | Valeur locale | Valeur démo mobile |
+Variables modifiées dans `backend/.env` :
+
+| Variable | Valeur locale | Valeur mobile |
 |---|---|---|
 | `GOOGLE_REDIRECT_URI` | `http://localhost:8000/auth/google/callback` | `https://bullpen-unafraid-mutual.ngrok-free.dev/auth/google/callback` |
 | `FRONTEND_URL` | `http://localhost:3000` | `https://bullpen-unafraid-mutual.ngrok-free.dev` |
+| `APP_URL` | `http://localhost:8000` | `https://bullpen-unafraid-mutual.ngrok-free.dev` |
+| `SANCTUM_STATEFUL_DOMAINS` | `localhost:3000,...` | `bullpen-unafraid-mutual.ngrok-free.dev,localhost:3000,...` |
+| `SESSION_DOMAIN` | `null` | `.bullpen-unafraid-mutual.ngrok-free.dev` |
+| `SESSION_SECURE_COOKIE` | `false` | `true` |
+| `SESSION_SAME_SITE` | `lax` | `none` |
 
-`make demo-stop` restaure les valeurs localhost.
+`make mobile-stop` restaure toutes ces valeurs et repasse le frontend en mode dev (`npm run dev`).
 
-#### Fichiers concernés
+### Fichiers concernés
 
 | Fichier | Rôle |
 |---|---|
-| `scripts/demo-start.sh` | Activation du mode démo (env + ngrok) |
-| `scripts/demo-stop.sh` | Restauration du mode local |
+| `ngrok.yml` | Config du tunnel ngrok (domaine fixe, port 3000) |
+| `docker-compose.mobile.yml` | Override Docker : frontend en mode `build + preview` |
+| `scripts/mobile.sh` | Configuration complète + ngrok + QR code |
+| `scripts/mobile-stop.sh` | Restauration mode local + frontend dev |
+| `frontend/.env` | `VITE_API_URL=/api` |
 
 ---
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,5 +1,42 @@
 import { createRoot } from 'react-dom/client';
+import { Component } from 'react';
 import './index.css';
 import App from './App.jsx';
 
-createRoot(document.getElementById('root')).render(<App />);
+class ErrorBoundary extends Component {
+  state = { erreur: null };
+
+  static getDerivedStateFromError(e) {
+    return { erreur: e };
+  }
+
+  render() {
+    if (this.state.erreur) {
+      return (
+        <div style={{ padding: '20px', fontFamily: 'monospace', color: 'red' }}>
+          <h2>Erreur React</h2>
+          <pre style={{ whiteSpace: 'pre-wrap' }}>{this.state.erreur.message}</pre>
+          <pre style={{ whiteSpace: 'pre-wrap', fontSize: '12px', color: '#666' }}>
+            {this.state.erreur.stack}
+          </pre>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+try {
+  createRoot(document.getElementById('root')).render(
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
+  );
+} catch (e) {
+  document.getElementById('root').innerHTML =
+    `<div style="padding:20px;color:red;font-family:monospace">
+      <h2>Erreur d'initialisation</h2>
+      <pre>${e.message}</pre>
+      <pre style="font-size:12px;color:#666">${e.stack}</pre>
+    </div>`;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -26,4 +26,22 @@ export default defineConfig({
       },
     },
   },
+  preview: {
+    port: 3000,
+    host: true,
+    proxy: {
+      '/api': {
+        target: 'http://backend:8000',
+        changeOrigin: true,
+      },
+      '/auth/google/redirect': {
+        target: 'http://backend:8000',
+        changeOrigin: true,
+      },
+      '/auth/google/callback': {
+        target: 'http://backend:8000',
+        changeOrigin: true,
+      },
+    },
+  },
 });

--- a/scripts/mobile-stop.sh
+++ b/scripts/mobile-stop.sh
@@ -1,4 +1,30 @@
 #!/bin/bash
+set -e
+
+PROJET_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$PROJET_ROOT/backend/.env"
 
 pkill ngrok 2>/dev/null || true
 echo "ngrok arrêté."
+
+# Restauration des URLs localhost dans .env
+echo "Retour en mode local (localhost)..."
+sed -i "s|^GOOGLE_REDIRECT_URI=.*|GOOGLE_REDIRECT_URI=http://localhost:8000/auth/google/callback|" "$ENV_FILE"
+sed -i "s|^FRONTEND_URL=.*|FRONTEND_URL=http://localhost:3000|" "$ENV_FILE"
+sed -i "s|^APP_URL=.*|APP_URL=http://localhost:8000|" "$ENV_FILE"
+sed -i "s|^SESSION_DOMAIN=.*|SESSION_DOMAIN=null|" "$ENV_FILE"
+sed -i "s|^SESSION_SECURE_COOKIE=.*|SESSION_SECURE_COOKIE=false|" "$ENV_FILE"
+sed -i "s|^SESSION_SAME_SITE=.*|SESSION_SAME_SITE=lax|" "$ENV_FILE"
+
+# Redémarrage du backend pour recharger .env
+echo "Redémarrage du backend..."
+docker compose -f "$PROJET_ROOT/docker-compose.yml" restart backend > /dev/null 2>&1
+
+# Retour au frontend en mode dev
+echo "Retour au frontend en mode dev..."
+docker compose -f "$PROJET_ROOT/docker-compose.yml" up -d --no-deps --force-recreate frontend > /dev/null 2>&1
+
+echo ""
+echo "======================================"
+echo "  Mode local restauré."
+echo "======================================"

--- a/scripts/mobile.sh
+++ b/scripts/mobile.sh
@@ -33,6 +33,40 @@ if [ -z "$FRONTEND_URL" ]; then
   exit 1
 fi
 
+NGROK_DOMAIN=$(echo "$FRONTEND_URL" | sed -e 's|^[^/]*//||' -e 's|/.*$||')
+
+# Mise à jour du backend .env
+ENV_FILE="$PROJET_ROOT/backend/.env"
+echo "Mise à jour du backend avec l'URL : $FRONTEND_URL"
+sed -i "s|^GOOGLE_REDIRECT_URI=.*|GOOGLE_REDIRECT_URI=${FRONTEND_URL}/auth/google/callback|" "$ENV_FILE"
+sed -i "s|^FRONTEND_URL=.*|FRONTEND_URL=${FRONTEND_URL}|" "$ENV_FILE"
+sed -i "s|^APP_URL=.*|APP_URL=${FRONTEND_URL}|" "$ENV_FILE"
+sed -i "s|^SANCTUM_STATEFUL_DOMAINS=.*|SANCTUM_STATEFUL_DOMAINS=${NGROK_DOMAIN},localhost:3000,127.0.0.1:3000|" "$ENV_FILE"
+sed -i "s|^SESSION_DOMAIN=.*|SESSION_DOMAIN=.${NGROK_DOMAIN}|" "$ENV_FILE"
+sed -i "s|^SESSION_SECURE_COOKIE=.*|SESSION_SECURE_COOKIE=true|" "$ENV_FILE"
+sed -i "s|^SESSION_SAME_SITE=.*|SESSION_SAME_SITE=none|" "$ENV_FILE"
+
+# Redémarrage du backend pour recharger .env
+echo "Redémarrage du backend..."
+docker compose -f "$PROJET_ROOT/docker-compose.yml" restart backend > /dev/null 2>&1
+
+# Build du frontend et démarrage en mode preview (production)
+echo "Build du frontend (peut prendre ~30s)..."
+docker compose -f "$PROJET_ROOT/docker-compose.yml" -f "$PROJET_ROOT/docker-compose.mobile.yml" up -d --no-deps --force-recreate frontend > /dev/null 2>&1
+
+# Attendre que le frontend soit prêt (max 120s)
+echo "Attente du frontend..."
+for i in $(seq 1 120); do
+  if curl -s http://localhost:3000 > /dev/null 2>&1; then
+    break
+  fi
+  if [ "$i" -eq 120 ]; then
+    echo "Erreur : le frontend n'a pas démarré en 120s."
+    exit 1
+  fi
+  sleep 1
+done
+
 echo ""
 echo "======================================"
 echo "  Ouvre sur ton téléphone :"
@@ -41,5 +75,5 @@ echo "======================================"
 echo ""
 qrencode -t ANSIUTF8 "$FRONTEND_URL"
 echo ""
-echo "  (Ctrl+C pour arrêter ngrok)"
+echo "  (Ctrl+C ou 'make mobile-stop' pour revenir en mode local)"
 wait


### PR DESCRIPTION
## Problème

Après `make mobile`, la page s'affiche correctement sur Chrome Android mais reste blanche sur Safari iOS.

**Cause identifiée** : Vite en mode dev sert ~95 modules JS séparément. Via Ngrok, chaque module fait un aller-retour réseau. Safari iOS abandonne le chargement avant que tous les modules arrivent ; Chrome Android est plus tolérant sur les timeouts.

## Solution

`make mobile` bascule le frontend en **build de production** (`vite preview`) au lieu du dev server. Le build produit 3 fichiers (HTML + CSS + JS bundlé) au lieu de 95 — Safari les charge sans problème.

## Changements

- `docker-compose.mobile.yml` — override du service frontend : `npm run build && npm run preview`
- `vite.config.js` — section `preview` avec proxy vers le backend (même config que `server.proxy`)
- `scripts/mobile.sh` — met à jour le `.env` backend (SESSION_DOMAIN, SANCTUM_STATEFUL_DOMAINS, SESSION_SECURE_COOKIE, SESSION_SAME_SITE, APP_URL) puis redémarre le frontend en mode preview et attend qu'il soit prêt
- `scripts/mobile-stop.sh` — restaure le `.env` et repasse le frontend en mode dev
- `frontend/src/main.jsx` — ajout d'un `ErrorBoundary` pour afficher les erreurs React à l'écran en production (remplace l'overlay Vite absent en preview)

## Test

```bash
make mobile       # build (~30s) puis QR code
# Scanner sur Safari iOS → page login visible
make mobile-stop  # retour en dev
```