### PR TITLE
feat: scan natif QR pour emargement

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,4 +10,6 @@
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
+  <script src="https://cdn.jsdelivr.net/npm/eruda"></script>
+  <script>eruda.init();</script>
 </html>

--- a/frontend/src/pages/Enseignant/SessionQR.jsx
+++ b/frontend/src/pages/Enseignant/SessionQR.jsx
@@ -150,7 +150,7 @@ const SessionQR = () => {
   };
 
   const urlQR = jeton
-    ? `https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=${encodeURIComponent(JSON.stringify({ idSession: session?.id, jeton }))}`
+    ? `https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=${encodeURIComponent(`${window.location.origin}/etudiant/scan?jeton=${jeton}`)}`
     : '';
 
   return (

--- a/frontend/src/pages/Etudiant/ScanPresence.jsx
+++ b/frontend/src/pages/Etudiant/ScanPresence.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Navigate, useSearchParams } from 'react-router-dom';
+import React, { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Html5Qrcode } from 'html5-qrcode';
 import './ScanPresence.css';
 
@@ -89,6 +89,13 @@ const ScanPresence = () => {
     }
   }, []);
 
+  useLayoutEffect(() => {
+    if (jetonNatif && !token) {
+      sessionStorage.setItem('redirectApresLogin', '/etudiant/scan');
+      window.location.replace('/login');
+    }
+  }, []);
+
   // Scan natif : jeton dans l'URL + étudiant déjà connecté
   useEffect(() => {
     if (!jetonNatif || !token) return;
@@ -148,12 +155,6 @@ const ScanPresence = () => {
       stopScanner();
     };
   }, [handleEmargement, jetonNatif]);
-
-  // Scan natif sans session : redirection login (après tous les hooks)
-  if (jetonNatif && !token) {
-    sessionStorage.setItem('redirectApresLogin', '/etudiant/scan');
-    return <Navigate to="/login" replace />;
-  }
 
   return (
     <div className="scan-container">

--- a/frontend/src/pages/Etudiant/ScanPresence.jsx
+++ b/frontend/src/pages/Etudiant/ScanPresence.jsx
@@ -1,8 +1,12 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Html5Qrcode } from 'html5-qrcode';
 import './ScanPresence.css';
 
 const ScanPresence = () => {
+  const [searchParams] = useSearchParams();
+  const jetonNatif = searchParams.get('jeton');
+
   const [statut, setStatut] = useState('chargement'); // chargement, lecture, validation, succes, erreur
   const [message, setMessage] = useState('');
   const scannerRef = useRef(null);
@@ -46,10 +50,10 @@ const ScanPresence = () => {
 
     let jeton = donnees;
     try {
-      const parsed = JSON.parse(donnees);
-      if (parsed.jeton) jeton = parsed.jeton;
+      const url = new URL(donnees);
+      jeton = url.searchParams.get('jeton') || donnees;
     } catch {
-      console.warn('Données scannées non JSON, utilisation brute:', donnees);
+      // fallback: valeur brute du QR si ce n'est pas une URL
     }
 
     try {
@@ -84,7 +88,27 @@ const ScanPresence = () => {
     }
   }, []);
 
+  // redirect vers login si pas de token d'authentification
   useEffect(() => {
+    if (!jetonNatif) return;
+
+    const token = localStorage.getItem('token');
+    if (!token) {
+      sessionStorage.setItem(
+        'redirectApresLogin',
+        window.location.pathname + window.location.search
+      );
+      window.location.href = '/login';
+      return;
+    }
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    handleEmargement(jetonNatif);
+  }, [jetonNatif, handleEmargement]);
+
+  useEffect(() => {
+    if (jetonNatif) return; // Ne pas démarrer le scanner si on a déjà un jeton à traiter
+
     const html5QrCode = new Html5Qrcode('reader');
     scannerRef.current = html5QrCode;
     let monte = true;
@@ -133,7 +157,7 @@ const ScanPresence = () => {
       };
       stopScanner();
     };
-  }, [handleEmargement]);
+  }, [handleEmargement, jetonNatif]);
 
   return (
     <div className="scan-container">

--- a/frontend/src/pages/Etudiant/ScanPresence.jsx
+++ b/frontend/src/pages/Etudiant/ScanPresence.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Navigate, useSearchParams } from 'react-router-dom';
 import { Html5Qrcode } from 'html5-qrcode';
 import './ScanPresence.css';
 
 const ScanPresence = () => {
   const [searchParams] = useSearchParams();
   const jetonNatif = searchParams.get('jeton');
+  const token = localStorage.getItem('token');
 
   const [statut, setStatut] = useState('chargement'); // chargement, lecture, validation, succes, erreur
   const [message, setMessage] = useState('');
@@ -57,12 +58,12 @@ const ScanPresence = () => {
     }
 
     try {
-      const token = localStorage.getItem('token');
+      const authToken = localStorage.getItem('token');
       const reponse = await fetch(`${import.meta.env.VITE_API_URL}/presences/valider-qr`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${authToken}`,
           Accept: 'application/json',
         },
         body: JSON.stringify({
@@ -88,26 +89,15 @@ const ScanPresence = () => {
     }
   }, []);
 
-  // redirect vers login si pas de token d'authentification
+  // Scan natif : jeton dans l'URL + étudiant déjà connecté
   useEffect(() => {
-    if (!jetonNatif) return;
-
-    const token = localStorage.getItem('token');
-    if (!token) {
-      sessionStorage.setItem(
-        'redirectApresLogin',
-        window.location.pathname + window.location.search
-      );
-      window.location.href = '/login';
-      return;
-    }
-
+    if (!jetonNatif || !token) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect
     handleEmargement(jetonNatif);
-  }, [jetonNatif, handleEmargement]);
+  }, [jetonNatif, token, handleEmargement]);
 
   useEffect(() => {
-    if (jetonNatif) return; // Ne pas démarrer le scanner si on a déjà un jeton à traiter
+    if (jetonNatif) return;
 
     const html5QrCode = new Html5Qrcode('reader');
     scannerRef.current = html5QrCode;
@@ -158,6 +148,12 @@ const ScanPresence = () => {
       stopScanner();
     };
   }, [handleEmargement, jetonNatif]);
+
+  // Scan natif sans session : redirection login (après tous les hooks)
+  if (jetonNatif && !token) {
+    sessionStorage.setItem('redirectApresLogin', '/etudiant/scan');
+    return <Navigate to="/login" replace />;
+  }
 
   return (
     <div className="scan-container">

--- a/frontend/src/pages/Login/LoginChoicePage.jsx
+++ b/frontend/src/pages/Login/LoginChoicePage.jsx
@@ -59,7 +59,10 @@ export default function LoginChoicePage() {
       if (res.ok) {
         localStorage.setItem('token', data.token);
         localStorage.setItem('user', JSON.stringify(data.user));
-        navigate(ROLES[role].redirect);
+        // redirection si jamais scan natif d'un étudiant:
+        const scanRedirect = sessionStorage.getItem('redirectApresLogin');
+        sessionStorage.removeItem('redirectApresLogin');
+        navigate(scanRedirect || ROLES[role].redirect);
       } else {
         setErreur(data.message || 'Identifiants incorrects');
       }


### PR DESCRIPTION
## Changements

- QR code contient une URL (`/etudiant/scan?jeton=XXX`) au lieu d'un JSON
- Detection du jeton dans l'URL via `useSearchParams`
- Si connecte: emargement direct sans ouvrir la camera
- Si non connecte: redirection vers `/login` puis retour sur `/etudiant/scan`
- Scanner camera ne demarre pas si jeton natif present

## Limitation connue

Redirection vers login depuis un scan natif sur iOS - page blanche (lié au contexte ngrok en dev). Fonctionne sur Android. A re-tester en production.