### PR TITLE
fix: relancer camera iOS sans rafraichir la page

### DIFF
--- a/frontend/src/pages/Etudiant/ScanPresence.css
+++ b/frontend/src/pages/Etudiant/ScanPresence.css
@@ -184,6 +184,67 @@
     background-color: var(--primary-hover);
 }
 
+.retry-button--overlay {
+    margin-top: 1.25rem;
+    padding: 0.6rem 1.25rem;
+    width: auto;
+    font-size: 0.9rem;
+    background-color: var(--primary-color);
+    color: white;
+    border: none;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+}
+
+.retry-button--overlay:hover {
+    background-color: var(--primary-hover);
+}
+
+.retry-button--link {
+    position: absolute;
+    bottom: 0.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 0.8rem;
+    cursor: pointer;
+    text-decoration: underline;
+    z-index: 6;
+    white-space: nowrap;
+    padding: 0.25rem 0.5rem;
+}
+
+.retry-button--link:hover {
+    color: white;
+}
+
+.camera-permission-guide {
+    text-align: left;
+    width: 100%;
+    margin-bottom: 1.5rem;
+}
+
+.camera-permission-guide__titre {
+    font-weight: 600;
+    color: var(--color-dark);
+    margin-bottom: 0.75rem;
+    font-size: 0.95rem;
+}
+
+.camera-permission-guide__steps {
+    padding-left: 1.25rem;
+    margin: 0 0 1.25rem;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    line-height: 1.6;
+}
+
+.camera-permission-guide__steps li {
+    margin-bottom: 0.5rem;
+}
+
 .info-message {
     margin-top: 1.5rem;
     padding: 1rem 1.5rem;

--- a/frontend/src/pages/Etudiant/ScanPresence.jsx
+++ b/frontend/src/pages/Etudiant/ScanPresence.jsx
@@ -19,6 +19,8 @@ const ScanPresence = () => {
   const [statut, setStatut] = useState('chargement'); // chargement, lecture, validation, succes, erreur
   const [message, setMessage] = useState('');
   const [scanKey, setScanKey] = useState(0);
+  const [cameraBloquee, setCameraBloquee] = useState(false);
+  const [permissionRefusee, setPermissionRefusee] = useState(false);
   const scannerRef = useRef(null);
   // Ref miroir pour éviter la closure stale sur localisation
   const localisationRef = useRef(null);
@@ -44,6 +46,28 @@ const ScanPresence = () => {
         }
       );
     }
+  }, []);
+
+  // Timeout : si la caméra ne démarre pas en 5s (iOS Safari), on affiche le bouton relancer
+  useEffect(() => {
+    if (statut !== 'chargement') {
+      setCameraBloquee(false);
+      return;
+    }
+    const timer = setTimeout(() => setCameraBloquee(true), 5000);
+    return () => clearTimeout(timer);
+  }, [statut, scanKey]);
+
+  const relancerCamera = useCallback(() => {
+    // Vider le DOM du reader pour éviter l'erreur "already started" sur iOS
+    const readerEl = document.getElementById('reader');
+    if (readerEl) readerEl.innerHTML = '';
+    dejaTraiteRef.current = false;
+    setCameraBloquee(false);
+    setPermissionRefusee(false);
+    setStatut('chargement');
+    setMessage('');
+    setScanKey((k) => k + 1);
   }, []);
 
   const handleEmargement = useCallback(async (donnees) => {
@@ -155,8 +179,17 @@ const ScanPresence = () => {
           return;
         }
         console.error('Impossible de démarrer la caméra', err);
+        const estRefus =
+          (err instanceof DOMException && err.name === 'NotAllowedError') ||
+          (typeof err === 'string' &&
+            (err.toLowerCase().includes('permission') ||
+              err.toLowerCase().includes('notallowed') ||
+              err.toLowerCase().includes('not allowed')));
+        setPermissionRefusee(estRefus);
         setStatut('erreur');
-        setMessage("L'accès à la caméra a été refusé ou n'est pas disponible.");
+        setMessage(
+          estRefus ? "L'accès à la caméra a été refusé." : "La caméra n'a pas pu démarrer."
+        );
       }
     };
 
@@ -251,9 +284,21 @@ const ScanPresence = () => {
               <div className="scanner-overlay">
                 <div className="spinner"></div>
                 <p>Initialisation caméra...</p>
+                {cameraBloquee && (
+                  <button onClick={relancerCamera} className="retry-button retry-button--overlay">
+                    La caméra ne répond pas - Relancer
+                  </button>
+                )}
               </div>
             )}
-            {statut === 'lecture' && <div className="scan-region-highlight"></div>}
+            {statut === 'lecture' && (
+              <>
+                <div className="scan-region-highlight"></div>
+                <button onClick={relancerCamera} className="retry-button--link">
+                  Relancer la caméra
+                </button>
+              </>
+            )}
           </div>
         )}
 
@@ -277,17 +322,27 @@ const ScanPresence = () => {
             <div className="icon">✕</div>
             <h2>Échec</h2>
             <p>{message}</p>
-            <button
-              onClick={() => {
-                dejaTraiteRef.current = false;
-                setStatut('chargement');
-                setMessage('');
-                setScanKey((k) => k + 1);
-              }}
-              className="retry-button"
-            >
-              Réessayer
-            </button>
+            {permissionRefusee ? (
+              <div className="camera-permission-guide">
+                <p className="camera-permission-guide__titre">Comment autoriser la caméra :</p>
+                <ol className="camera-permission-guide__steps">
+                  <li>
+                    <strong>iOS Safari</strong> : Réglages &gt; Safari &gt; Caméra &gt; Autoriser
+                  </li>
+                  <li>
+                    <strong>Android Chrome</strong> : appuyez sur l&apos;icône cadenas dans la barre
+                    d&apos;adresse &gt; Caméra &gt; Autoriser
+                  </li>
+                </ol>
+                <button onClick={relancerCamera} className="retry-button">
+                  J&apos;ai autorisé la caméra - Réessayer
+                </button>
+              </div>
+            ) : (
+              <button onClick={relancerCamera} className="retry-button">
+                Réessayer
+              </button>
+            )}
           </div>
         )}
       </main>


### PR DESCRIPTION
## Problème

Sur iOS Safari, la camera restait bloquée en \"Initialisation...\" au premier chargement. L'etudiant devait rafraichir la page car iOS Safari exige un geste utilisateur pour demarrer getUserMedia.

## Solution

- Timeout 5s : si la camera ne demarre pas, un bouton \"La camera ne repond pas - Relancer\" apparait dans l'overlay. Le tap sur ce bouton fournit le geste utilisateur qu'iOS attendait.
- Bouton discret \"Relancer la camera\" toujours visible pendant le scan (camera figee possible).
- Detection permission refusee (NotAllowedError) : instructions specifiques iOS/Android plutot qu'un retry inutile.
- Nettoyage du DOM du reader avant reinit pour eviter l'erreur \"already started\".

## Test

- iOS Safari : ouvrir la page scan, attendre 5s, tapper \"Relancer\" - la camera doit demarrer.
- Permission refusee : verifier que les instructions apparaissent avec le bouton \"J'ai autorise la camera\".